### PR TITLE
Fix menu bar `Complete` action

### DIFF
--- a/extensions/things/CHANGELOG.md
+++ b/extensions/things/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Things Changelog
 
+## [✨ Fix Complete Menu Bar Action] - {PR_MERGE_DATE}
+
+- Fix `Complete` menu bar action to mark the first incomplete todo as complete, rather than completing the first item in the list, even if it is already marked as completed.
+
 ## [✨ Menu Bar Todo] - 2025-04-14
 
 - Update the menu bar to display only incomplete todos from today’s list

--- a/extensions/things/src/show-today-in-menu-bar.tsx
+++ b/extensions/things/src/show-today-in-menu-bar.tsx
@@ -64,8 +64,8 @@ export default function ShowTodayInMenuBar() {
     <MenuBarExtra icon="things-flat.png" title={title} tooltip={tooltip} isLoading={isLoading}>
       {todos && todos.length > 0 ? (
         <>
-          {displayTodo ? (
-            <MenuBarExtra.Item title="Complete" icon={Icon.CheckCircle} onAction={() => completeTodo(todos[0])} />
+          {displayTodo && firstIncompleteTodo ? (
+            <MenuBarExtra.Item title="Complete" icon={Icon.CheckCircle} onAction={() => completeTodo(firstIncompleteTodo)} />
           ) : null}
           <MenuBarExtra.Section>
             <MenuBarExtra.Item title="Today" />

--- a/extensions/things/src/show-today-in-menu-bar.tsx
+++ b/extensions/things/src/show-today-in-menu-bar.tsx
@@ -65,7 +65,11 @@ export default function ShowTodayInMenuBar() {
       {todos && todos.length > 0 ? (
         <>
           {displayTodo && firstIncompleteTodo ? (
-            <MenuBarExtra.Item title="Complete" icon={Icon.CheckCircle} onAction={() => completeTodo(firstIncompleteTodo)} />
+            <MenuBarExtra.Item
+              title="Complete"
+              icon={Icon.CheckCircle}
+              onAction={() => completeTodo(firstIncompleteTodo)}
+            />
           ) : null}
           <MenuBarExtra.Section>
             <MenuBarExtra.Item title="Today" />


### PR DESCRIPTION
## Description

We introduced an update to display the first incomplete item in the menu bar instead of the first item, regardless of its completion status. However, the completion action still affects the first item in the list instead of the first incomplete item.

## Screencast

/

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
